### PR TITLE
Gracefully handle missing delombok directory

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -14,6 +14,6 @@ runs:
         echo "Inputs:"
         echo "  directory: ${{ inputs.delombokSourcePath }}"
         echo "---- Start of Delomboked source files ----"
-        find "${{ inputs.delombokSourcePath }}" -type f -print -exec cat -n {} \;
+        if [ -d "${{ inputs.delombokSourcePath }}" ]; then find "${{ inputs.delombokSourcePath }}" -type f -print -exec cat -n {} \; ; echo "No delomboked sources found. Directory ${{ inputs.delombokSourcePath }} does not exist" ; fi
         echo "---- End of Delomboked source files ----"
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -14,6 +14,6 @@ runs:
         echo "Inputs:"
         echo "  directory: ${{ inputs.delombokSourcePath }}"
         echo "---- Start of Delomboked source files ----"
-        if [ -d "${{ inputs.delombokSourcePath }}" ]; then find "${{ inputs.delombokSourcePath }}" -type f -print -exec cat -n {} \; ; else echo "No delomboked sources found. Directory ${{ inputs.delombokSourcePath }} does not exist." ; fi
+        if [ -d "${{ inputs.delombokSourcePath }}" ]; then find "${{ inputs.delombokSourcePath }}" -type f -print -exec cat -n {} \; ; else echo "No delomboked sources found. Directory '${{ inputs.delombokSourcePath }}' does not exist." ; fi
         echo "---- End of Delomboked source files ----"
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -14,6 +14,6 @@ runs:
         echo "Inputs:"
         echo "  directory: ${{ inputs.delombokSourcePath }}"
         echo "---- Start of Delomboked source files ----"
-        if [ -d "${{ inputs.delombokSourcePath }}" ]; then find "${{ inputs.delombokSourcePath }}" -type f -print -exec cat -n {} \; ; echo "No delomboked sources found. Directory ${{ inputs.delombokSourcePath }} does not exist" ; fi
+        if [ -d "${{ inputs.delombokSourcePath }}" ]; then find "${{ inputs.delombokSourcePath }}" -type f -print -exec cat -n {} \; ; else echo "No delomboked sources found. Directory ${{ inputs.delombokSourcePath }} does not exist" ; fi
         echo "---- End of Delomboked source files ----"
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -14,6 +14,6 @@ runs:
         echo "Inputs:"
         echo "  directory: ${{ inputs.delombokSourcePath }}"
         echo "---- Start of Delomboked source files ----"
-        if [ -d "${{ inputs.delombokSourcePath }}" ]; then find "${{ inputs.delombokSourcePath }}" -type f -print -exec cat -n {} \; ; else echo "No delomboked sources found. Directory ${{ inputs.delombokSourcePath }} does not exist" ; fi
+        if [ -d "${{ inputs.delombokSourcePath }}" ]; then find "${{ inputs.delombokSourcePath }}" -type f -print -exec cat -n {} \; ; else echo "No delomboked sources found. Directory ${{ inputs.delombokSourcePath }} does not exist." ; fi
         echo "---- End of Delomboked source files ----"
       shell: bash


### PR DESCRIPTION
Instead of the action failing if the delombok directory does not exist, print out a useful message.

Closes #3